### PR TITLE
Add simple personal webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Leonardo Giusti</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 40px auto;
+            line-height: 1.6;
+        }
+    </style>
+    <!-- Attempt to import shadcn UI library -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/shadcn-ui/dist/shadcn-ui.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/shadcn-ui/dist/shadcn-ui.min.js"></script>
+</head>
+<body>
+    <p>Hello, my name is Leonardo Giusti.</p>
+
+    <p>I am Founder and Design Director at Archetype AI​. Before, I was Head of Design at Google ATAP - Project Soli and Jacquard, Design Lead at Samsung Design, and a Researcher at MIT Design Lab.</p>
+
+    <p>One day I will find the energy to put together an online portfolio. Maybe. In the meanwhile, here's a write-up about my work at Archetype: FastCo, and a podcast: Design This Day. And a couple of articles about my previous work at Google: FastCo, Wired</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with short bio content
- try importing shadcn UI library from CDN

## Testing
- `git show -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68636fa004888333a55f6bb339f004af